### PR TITLE
nvim: override pyproject toml schema

### DIFF
--- a/.config/nvim/after/lsp/tombi.lua
+++ b/.config/nvim/after/lsp/tombi.lua
@@ -1,0 +1,13 @@
+return {
+  settings = {
+    tombi = {
+      schemas = {
+        {
+          root = "tool.pyright",
+          path = "https://raw.githubusercontent.com/DetachHead/basedpyright/refs/heads/main/packages/vscode-pyright/schemas/pyrightconfig.schema.json",
+          include = { "pyproject.toml" },
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
use basedpyright instead